### PR TITLE
chore: output release information for use in other tools

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,3 +74,9 @@ if [ "${CREATE_RELEASE}" = "true" ] || [ "${CREATE_RELEASE}" = true ]; then
 fi
 
 echo "release=${NEXT_RELEASE}" >>$GITHUB_OUTPUT
+echo "title=${NAME}" >>$GITHUB_OUTPUT
+echo "changelog=${MESSAGE}" >>$GITHUB_OUTPUT
+echo "draft=${DRAFT}" >>$GITHUB_OUTPUT
+echo "pre=${PRE}" >>$GITHUB_OUTPUT
+
+


### PR DESCRIPTION
add capability to use generated information in other release tools for releasing to other endpoints such as pypi, docker, debchange, etc